### PR TITLE
Updated DocumentDb client package ref

### DIFF
--- a/assets/CommonAssemblyInfo.cs
+++ b/assets/CommonAssemblyInfo.cs
@@ -1,5 +1,5 @@
 using System.Reflection;
 
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.1.1.1")]
-[assembly: AssemblyInformationalVersion("1.0.0")]
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]
+[assembly: AssemblyInformationalVersion("0.0.0")]

--- a/assets/CommonAssemblyInfo.cs
+++ b/assets/CommonAssemblyInfo.cs
@@ -1,5 +1,5 @@
 using System.Reflection;
 
-[assembly: AssemblyVersion("0.0.0.0")]
-[assembly: AssemblyFileVersion("0.0.0.0")]
-[assembly: AssemblyInformationalVersion("0.0.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.1.1.1")]
+[assembly: AssemblyInformationalVersion("1.0.0")]

--- a/src/Serilog.Sinks.AzureDocumentDb/Serilog.Sinks.AzureDocumentDb.csproj
+++ b/src/Serilog.Sinks.AzureDocumentDb/Serilog.Sinks.AzureDocumentDb.csproj
@@ -36,18 +36,21 @@
     <AssemblyOriginatorKeyFile>..\..\assets\Serilog.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Azure.Documents.Client">
-      <HintPath>..\..\packages\Microsoft.Azure.Documents.Client.0.9.0-preview\lib\net40\Microsoft.Azure.Documents.Client.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.5.0\lib\net40\Microsoft.Azure.Documents.Client.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.5.0.7\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog, Version=1.4.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Serilog.1.4.204\lib\net45\Serilog.dll</HintPath>
+    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.1.5.12\lib\net45\Serilog.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog.FullNetFx">
-      <HintPath>..\..\packages\Serilog.1.4.204\lib\net45\Serilog.FullNetFx.dll</HintPath>
+    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.1.5.12\lib\net45\Serilog.FullNetFx.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Serilog.Sinks.AzureDocumentDb/Serilog.Sinks.AzureDocumentDb.nuspec
+++ b/src/Serilog.Sinks.AzureDocumentDb/Serilog.Sinks.AzureDocumentDb.nuspec
@@ -12,7 +12,7 @@
     <tags>serilog logging azure</tags>
     <dependencies>
       <dependency id="Serilog" version="[1.4.204,2)" />
-      <dependency id="Microsoft.Azure.Documents.Client" version="0.9.0" />
+      <dependency id="Microsoft.Azure.DocumentDB" version="1.5.0" />
     </dependencies>
   </metadata>
 </package>

--- a/src/Serilog.Sinks.AzureDocumentDb/packages.config
+++ b/src/Serilog.Sinks.AzureDocumentDb/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.Documents.Client" version="0.9.0-preview" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
-  <package id="Serilog" version="1.4.204" targetFramework="net45" />
+  <package id="Microsoft.Azure.DocumentDB" version="1.5.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="5.0.7" targetFramework="net45" />
+  <package id="Serilog" version="1.5.12" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Updated the DocumentDb client package to use the Microsoft.Azure.DocumentDB rather than the deprecated Microsoft.Azure.Documents.Client package.

(this is my first pull request, so please let me know if I messed anything up!)