### PR TITLE
Add new flag to store timestamps as UTC time

### DIFF
--- a/src/Serilog.Sinks.AzureDocumentDb/LoggerConfigurationAzureDocumentDbExtensions.cs
+++ b/src/Serilog.Sinks.AzureDocumentDb/LoggerConfigurationAzureDocumentDbExtensions.cs
@@ -34,6 +34,7 @@ namespace Serilog
         /// <param name="collectionName">The name of the collection to use inside the database; will created if it doesn't exist.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="storeTimestampInUtc">Store Timestamp in UTC</param>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration AzureDocumentDB(
             this LoggerSinkConfiguration loggerConfiguration,
@@ -42,13 +43,14 @@ namespace Serilog
             string databaseName = "Diagnostics",
             string collectionName = "Logs",
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            bool storeTimestampInUtc = false)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
             if (endpointUri == null) throw new ArgumentNullException("endpointUri");
             if (authorizationKey == null) throw new ArgumentNullException("authorizationKey");
             return loggerConfiguration.Sink(
-                new AzureDocumentDBSink(endpointUri, authorizationKey, databaseName, collectionName, formatProvider),
+                new AzureDocumentDBSink(endpointUri, authorizationKey, databaseName, collectionName, formatProvider, storeTimestampInUtc),
                 restrictedToMinimumLevel);
         }
     }

--- a/src/Serilog.Sinks.AzureDocumentDb/Sinks/AzureDocumentDb/AzureDocumentDbSink.cs
+++ b/src/Serilog.Sinks.AzureDocumentDb/Sinks/AzureDocumentDb/AzureDocumentDbSink.cs
@@ -28,11 +28,13 @@ namespace Serilog.Sinks.AzureDocumentDb
         DocumentClient _client;
         Database _database;
         DocumentCollection _collection;
+        bool _storeTimestampInUtc;
 
-        public AzureDocumentDBSink(Uri endpointUri, string authorizationKey, string databaseName, string collectionName, IFormatProvider formatProvider)
+        public AzureDocumentDBSink(Uri endpointUri, string authorizationKey, string databaseName, string collectionName, IFormatProvider formatProvider, bool storeTimestampInUtc)
         {
             _formatProvider = formatProvider;
             _client = new DocumentClient(endpointUri, authorizationKey);
+            _storeTimestampInUtc = storeTimestampInUtc;
             Task.WaitAll(new []{CreateDatabaseIfNotExistsAsync(databaseName)});
             Task.WaitAll(new []{CreateCollectionIfNotExistsAsync(collectionName)});
         }
@@ -68,7 +70,7 @@ namespace Serilog.Sinks.AzureDocumentDb
 
         private Task EmitAsync(LogEvent logEvent)
         {
-            return _client.CreateDocumentAsync(_collection.SelfLink, new Data.LogEvent(logEvent, logEvent.RenderMessage(_formatProvider)));
+            return _client.CreateDocumentAsync(_collection.SelfLink, new Data.LogEvent(logEvent, logEvent.RenderMessage(_formatProvider), _storeTimestampInUtc));
         }
     }
 }

--- a/src/Serilog.Sinks.AzureDocumentDb/Sinks/AzureDocumentDb/Data/LogEvent.cs
+++ b/src/Serilog.Sinks.AzureDocumentDb/Sinks/AzureDocumentDb/Data/LogEvent.cs
@@ -33,9 +33,9 @@ namespace Serilog.Sinks.AzureDocumentDb.Data
         /// <summary>
         /// Construct a new <see cref="LogEvent"/>.
         /// </summary>
-        public LogEvent(Events.LogEvent logEvent, string renderedMessage)
+        public LogEvent(Events.LogEvent logEvent, string renderedMessage, bool storeTimestampInUtc)
         {
-            Timestamp = logEvent.Timestamp;
+            Timestamp = storeTimestampInUtc ? logEvent.Timestamp.ToUniversalTime() : logEvent.Timestamp;
             Exception = logEvent.Exception;
             MessageTemplate = logEvent.MessageTemplate.Text;
             Level = logEvent.Level;


### PR DESCRIPTION
Azure DocumentDB stores data in JSON format.  Since JSON doesn't have a defined datetime format, Microsoft converts the Timestamp to an ISO 8601 string.  To use these strings in a range comparison operations (less than, greater than, between,  etc...), it's important that all Timestamps be represented in the same timezone.  This flag allows the user to force Timestamp to use UTC time so they can safely be used in ranger operations.