### PR TITLE
Added support for Serilog version 2.1  and Azure DocumentDb v1.9

### DIFF
--- a/src/Serilog.Sinks.AzureDocumentDb/Serilog.Sinks.AzureDocumentDb.csproj
+++ b/src/Serilog.Sinks.AzureDocumentDb/Serilog.Sinks.AzureDocumentDb.csproj
@@ -9,8 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Serilog</RootNamespace>
     <AssemblyName>Serilog.Sinks.AzureDocumentDB</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -36,20 +39,16 @@
     <AssemblyOriginatorKeyFile>..\..\assets\Serilog.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.5.0\lib\net40\Microsoft.Azure.Documents.Client.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.9.3\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.5.0.7\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.FullNetFx.dll</HintPath>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.2.1.0\lib\net45\Serilog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -76,6 +75,13 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\Microsoft.Azure.DocumentDB.1.9.3\build\Microsoft.Azure.DocumentDB.targets" Condition="Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.9.3\build\Microsoft.Azure.DocumentDB.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.9.3\build\Microsoft.Azure.DocumentDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Azure.DocumentDB.1.9.3\build\Microsoft.Azure.DocumentDB.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Serilog.Sinks.AzureDocumentDb/Sinks/AzureDocumentDb/AzureDocumentDbSink.cs
+++ b/src/Serilog.Sinks.AzureDocumentDb/Sinks/AzureDocumentDb/AzureDocumentDbSink.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Serilog Contributors
+﻿// Copyright 2016 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 
 using System;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
@@ -35,42 +36,37 @@ namespace Serilog.Sinks.AzureDocumentDb
             _formatProvider = formatProvider;
             _client = new DocumentClient(endpointUri, authorizationKey);
             _storeTimestampInUtc = storeTimestampInUtc;
-            Task.WaitAll(new []{CreateDatabaseIfNotExistsAsync(databaseName)});
-            Task.WaitAll(new []{CreateCollectionIfNotExistsAsync(collectionName)});
+            CreateDatabaseIfNotExistsAsync(databaseName).ConfigureAwait(false);
+            CreateCollectionIfNotExistsAsync(collectionName).ConfigureAwait(false);
         }
 
         public void Emit(LogEvent logEvent)
         {
-            Task.WaitAll(EmitAsync(logEvent));
+            EmitAsync(logEvent).ConfigureAwait(false);
         }
 
         private async Task CreateDatabaseIfNotExistsAsync(string databaseName)
         {
-            _database = (await _client.ReadDatabaseFeedAsync())
-                .SingleOrDefault(d => d.Id == databaseName);
-
+            _database = _client.CreateDatabaseQuery().Where(x => x.Id == databaseName).AsEnumerable().FirstOrDefault();
             if (_database == null)
-                _database = await _client.CreateDatabaseAsync(new Database
-                {
-                    Id = databaseName
-                });
+            {
+                _database = await _client.CreateDatabaseAsync(new Microsoft.Azure.Documents.Database { Id = databaseName });
+            }
         }
 
         private async Task CreateCollectionIfNotExistsAsync(string collectionName)
         {
-            _collection = (await _client.ReadDocumentCollectionFeedAsync(_database.CollectionsLink))
-                .SingleOrDefault(c => c.Id == collectionName);
-
+            _collection = _client.CreateDocumentCollectionQuery(_database.SelfLink).Where(x => x.Id == collectionName).AsEnumerable().FirstOrDefault();
             if (_collection == null)
-                _collection = await _client.CreateDocumentCollectionAsync(_database.SelfLink, new DocumentCollection
-                {
-                    Id = collectionName
-                });
+            {
+                _collection = await _client.CreateDocumentCollectionAsync(_database.SelfLink, new DocumentCollection() { Id = collectionName });
+            }
         }
 
-        private Task EmitAsync(LogEvent logEvent)
+        private async Task<string> EmitAsync(LogEvent logEvent)
         {
-            return _client.CreateDocumentAsync(_collection.SelfLink, new Data.LogEvent(logEvent, logEvent.RenderMessage(_formatProvider), _storeTimestampInUtc));
+            var document = await _client.CreateDocumentAsync(_collection.SelfLink, new Data.LogEvent(logEvent, logEvent.RenderMessage(_formatProvider), _storeTimestampInUtc), new RequestOptions {}, false);
+            return document.ActivityId;
         }
     }
 }

--- a/src/Serilog.Sinks.AzureDocumentDb/packages.config
+++ b/src/Serilog.Sinks.AzureDocumentDb/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.DocumentDB" version="1.5.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="5.0.7" targetFramework="net45" />
-  <package id="Serilog" version="1.5.14" targetFramework="net45" />
+  <package id="Microsoft.Azure.DocumentDB" version="1.9.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="Serilog" version="2.1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Current version of AzureDocumentDB sink wasn't supported with latest Serilog version 2.1 and Azure Document DB version 1.9.*

Updated nuget dependencies to latest version and refactored code to use async/await pattern and new API to query existing database/collection.