### PR TITLE
Updated nuget dependencies version support.

### DIFF
--- a/src/Serilog.Sinks.AzureDocumentDb/Serilog.Sinks.AzureDocumentDb.nuspec
+++ b/src/Serilog.Sinks.AzureDocumentDb/Serilog.Sinks.AzureDocumentDb.nuspec
@@ -11,8 +11,8 @@
     <iconUrl>http://serilog.net/images/serilog-sink-nuget.png</iconUrl>
     <tags>serilog logging azure</tags>
     <dependencies>
-      <dependency id="Serilog" version="[1.5.14,2)" />
-      <dependency id="Microsoft.Azure.DocumentDB" version="1.5.0" />
+      <dependency id="Serilog" version="1.5.14" />
+      <dependency id="Microsoft.Azure.DocumentDB" version="1.9.0" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
Current nuget package doesn't work with latest Serilog and force you to install version prior than 1.5.

Removed upper Serilog version range in nuspec.