### PR TITLE
Workaround Azure DocumentDb bug.

### DIFF
--- a/src/Serilog.Sinks.AzureDocumentDb/Serilog.Sinks.AzureDocumentDb.nuspec
+++ b/src/Serilog.Sinks.AzureDocumentDb/Serilog.Sinks.AzureDocumentDb.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Serilog.Sinks.AzureDocumentDB</id>
     <version>$version$</version>
-    <authors>Robert Moore</authors>
+    <authors>Robert Moore, Saleem Mirza</authors>
     <description>Serilog event sink that writes to Azure DocumentDB over HTTP.</description>
     <language>en-US</language>
     <projectUrl>http://serilog.net</projectUrl>


### PR DESCRIPTION
Azure DocumentDb tends to block stored procedure if it's pushing too much documents in short time. Ideally Azure should be throttling as they mentioned in documentation but they are blacklisting.
For reference see [Stackoverflow question](http://stackoverflow.com/questions/29978925/documentdb-stored-procedure-blocked)

Mitigated issue but re-creating stored procedure if got hit.

@nblumhardt 