### PR TITLE
upgraded azure/serilog dependencies

### DIFF
--- a/src/Serilog.Sinks.AzureDocumentDb/Sinks/AzureDocumentDb/AzureDocumentDbSink.cs
+++ b/src/Serilog.Sinks.AzureDocumentDb/Sinks/AzureDocumentDb/AzureDocumentDbSink.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright 2016 Serilog Contributors
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/Serilog.Sinks.AzureDocumentDb/project.json
+++ b/src/Serilog.Sinks.AzureDocumentDb/project.json
@@ -1,6 +1,6 @@
 {
     "title": "Serilog.Sinks.AzureDocumentDB",
-    "version": "3.5.18-beta",
+    "version": "3.5.18-*",
     "description": "Serilog event sink that writes to Azure DocumentDb",
     "authors": [
         "Serilog Contributors"
@@ -23,19 +23,19 @@
         "embed": [ "/**/bulkImport.js" ],
         "define": []
     },
-  "dependencies": {
-    "Serilog": "2.3.0"
-  },
+    "dependencies": {
+        "Serilog": "2.3.0"
+    },
     "frameworks": {
         "netstandard1.6": {
-          "dependencies": {
-            "Microsoft.Azure.DocumentDB.Core": "1.0.0"
-          }
+            "dependencies": {
+                "Microsoft.Azure.DocumentDB.Core": "1.0.0"
+            }
         },
         "net452": {
-          "dependencies": {
-            "Microsoft.Azure.DocumentDB": "1.11.1"
-          }
+            "dependencies": {
+                "Microsoft.Azure.DocumentDB": "1.11.1"
+            }
         }
     }
 }

--- a/src/Serilog.Sinks.AzureDocumentDb/project.json
+++ b/src/Serilog.Sinks.AzureDocumentDb/project.json
@@ -1,6 +1,6 @@
 {
     "title": "Serilog.Sinks.AzureDocumentDB",
-    "version": "3.5.17-*",
+    "version": "3.5.18-beta",
     "description": "Serilog event sink that writes to Azure DocumentDb",
     "authors": [
         "Serilog Contributors"
@@ -23,19 +23,19 @@
         "embed": [ "/**/bulkImport.js" ],
         "define": []
     },
-    "dependencies": {
-        "Serilog": "2.2.1"
-    },
+  "dependencies": {
+    "Serilog": "2.3.0"
+  },
     "frameworks": {
         "netstandard1.6": {
-            "dependencies": {
-                "Microsoft.Azure.DocumentDB.Core": "0.1.0-*"
-            }
+          "dependencies": {
+            "Microsoft.Azure.DocumentDB.Core": "1.0.0"
+          }
         },
         "net452": {
-            "dependencies": {
-                "Microsoft.Azure.DocumentDB": "1.9.5"
-            }
+          "dependencies": {
+            "Microsoft.Azure.DocumentDB": "1.11.1"
+          }
         }
     }
 }


### PR DESCRIPTION
Hi,

Due to issue #42 I made this PR.

- document db nuget updated to 1.11.1 (most recent)
- serilog nuget updated to 2.3.0  (most recent)

Please do find some time to pull this in. I marked the nuget as a beta prerelease (so it can be tried before releasing). thx